### PR TITLE
#164923863 Add user passport photo delete functionality

### DIFF
--- a/api/settings/base.py
+++ b/api/settings/base.py
@@ -88,7 +88,7 @@ JWT_AUTH = {
     'JWT_ALLOW_REFRESH': False,
     'JWT_REFRESH_EXPIRATION_DELTA': datetime.timedelta(days=7),
 
-    'JWT_AUTH_HEADER_PREFIX': 'BEARER',
+    'JWT_AUTH_HEADER_PREFIX': 'Bearer',
     'JWT_AUTH_COOKIE': None,
 }
 

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -12,7 +12,7 @@ class UserSerializer(ModelSerializer):
     class Meta:
         model = User
         fields = ('id', 'email', 'password', 'first_name', 'last_name',
-                  'passport_photo', 'address', 'phone_number')
+                  'passport_photo', 'address', 'phone_number', 'updated_at')
         extra_kwargs = {'password': {'write_only': True}}
 
     def create(self, validated_data):

--- a/users/views.py
+++ b/users/views.py
@@ -11,7 +11,6 @@ from .serializers import UserSerializer, ImageSerializer
 from .helpers import get_token
 
 
-# Create your views here.
 class RegisterView(APIView):
     """
     Register a new user
@@ -85,13 +84,14 @@ class LoginView(APIView):
         },
         status=status.HTTP_401_UNAUTHORIZED)
 
+
 class ProfilePhotoView(APIView):
 
     def put(self, request, pk, format='json'):
         if request.user.id != pk:
             return Response({
                 'status': 'Error',
-                'message': 'Request forbidden'
+                'message': 'Request forbidden, not users profile'
             },
             status=status.HTTP_403_FORBIDDEN)
 
@@ -112,3 +112,25 @@ class ProfilePhotoView(APIView):
             'error': serializer.errors
         },
         status=status.HTTP_400_BAD_REQUEST)
+
+    def delete(self, request, pk, format='json'):
+        user = request.user
+        if user.id != pk:
+            return Response({
+                'status': 'Error',
+                'message': 'Request forbidden, not users passport photo'
+            },
+            status=status.HTTP_403_FORBIDDEN)
+
+        if user.passport_photo:
+            user.passport_photo.delete()
+            return Response({
+                'status': 'Success',
+                'message': 'User passport photo deleted'
+            },
+            status=status.HTTP_200_OK)
+        return Response({
+            'status': 'Error',
+            'message': 'User does not have a passport_photo'
+        },
+        status=status.HTTP_404_NOT_FOUND)

--- a/users/views.py
+++ b/users/views.py
@@ -102,6 +102,7 @@ class ProfilePhotoView(APIView):
         serializer = ImageSerializer(User.objects.get(pk=pk), data=request.data)
 
         if serializer.is_valid():
+            request.user.passport_photo.delete()
             serializer.save()
 
             return Response({

--- a/users/views.py
+++ b/users/views.py
@@ -126,7 +126,7 @@ class ProfilePhotoView(APIView):
             user.passport_photo.delete()
             return Response({
                 'status': 'Success',
-                'message': 'User passport photo deleted'
+                'message': 'Passport photo deleted'
             },
             status=status.HTTP_200_OK)
         return Response({

--- a/users/views.py
+++ b/users/views.py
@@ -86,7 +86,11 @@ class LoginView(APIView):
 
 
 class ProfilePhotoView(APIView):
+    """Profile photo
 
+    Arguments:
+        APIView {view} -- rest_framework API view
+    """
     def put(self, request, pk, format='json'):
         if request.user.id != pk:
             return Response({


### PR DESCRIPTION
#### What does this PR do?
- Add user passport photo delete functionality

#### Description of Task to be completed?
- A user should be able to delete their passport photo

#### How should this be manually tested?
- Fetch the branch with the command: `git fetch ft-user-photo-delete-164923863:ft-user-photo-delete-164923863`
- Checkout to the branch with the command: `git checkout ft-user-photo-delete-164923863`
- Start the server with the command: `python manage.py runserver`
- Upload passport photo by sending a request to the endpoint: `PUT 127.0.0.1:8000/api/v1/users/<user_id>/photo`
Sample request data:
```
{
	"passport_photo": "passport photo file",
}
```
- Test the delete passport photo by sending a request to: `DELETE 127.0.0.1:8000/api/v1/users/<user_id>/photo`

#### Any background context you want to provide?
- The image file is stored on AWS hence you need to set up an AWS account and create a bucket

#### What are the relevant pivotal tracker stories?
[#164923863](https://www.pivotaltracker.com/story/show/164923863)

#### Screenshots:
- N/A

#### Quesions:
- N/A